### PR TITLE
Fixed integration test by splitting into specific Scala 2.10 and 2.11 versions

### DIFF
--- a/scala-debugger-api/src/it/scala-2.10/org/senkbeil/debugger/requests/ScalaVirtualMachine210IntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala-2.10/org/senkbeil/debugger/requests/ScalaVirtualMachine210IntegrationSpec.scala
@@ -1,0 +1,42 @@
+package org.senkbeil.debugger.requests
+
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Milliseconds, Seconds, Span}
+import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
+import test.{TestUtilities, VirtualMachineFixtures}
+
+/** Specific to Scala 2.10 */
+class ScalaVirtualMachine210IntegrationSpec extends FunSpec with Matchers
+  with ParallelTestExecution with VirtualMachineFixtures
+  with TestUtilities with Eventually
+{
+  implicit override val patienceConfig = PatienceConfig(
+    timeout = scaled(Span(2, Seconds)),
+    interval = scaled(Span(5, Milliseconds))
+  )
+
+  describe("ScalaVirtualMachine for 2.10") {
+    it("should return the breakpointable line numbers for the file") {
+      val testClass = "org.senkbeil.test.misc.AvailableLines"
+
+      withVirtualMachine(testClass, suspend = false) { (_, scalaVirtualMachine) =>
+        // NOTE: In Scala 2.10, there is a breakpoint available on the object
+        //       itself (line 11), but there is not one on the last line of the
+        //       object (72) - verified with IntelliJ
+        val expected = Seq(
+          11, 12, 13, 14, 15, 16, 20, 21, 22, 26, 27, 28, 32, 34, 35, 37, 39,
+          40, 41, 42, 45, 46, 47, 50, 52, 53, 57, 58, 59, 60, 63, 65
+        )
+
+        val file = scalaClassStringToFileString(testClass)
+
+        // There is some delay while receiving the Java classes that make up
+        // our file, so must wait for enough responses to get all of our lines
+        eventually {
+          val actual = scalaVirtualMachine.availableLinesForFile(file).get
+          actual should contain theSameElementsInOrderAs expected
+        }
+      }
+    }
+  }
+}

--- a/scala-debugger-api/src/it/scala-2.11/org/senkbeil/debugger/requests/ScalaVirtualMachine211IntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala-2.11/org/senkbeil/debugger/requests/ScalaVirtualMachine211IntegrationSpec.scala
@@ -1,0 +1,42 @@
+package org.senkbeil.debugger.requests
+
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Milliseconds, Seconds, Span}
+import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
+import test.{TestUtilities, VirtualMachineFixtures}
+
+/** Specific to Scala 2.11 */
+class ScalaVirtualMachine211IntegrationSpec extends FunSpec with Matchers
+  with ParallelTestExecution with VirtualMachineFixtures
+  with TestUtilities with Eventually
+{
+  implicit override val patienceConfig = PatienceConfig(
+    timeout = scaled(Span(2, Seconds)),
+    interval = scaled(Span(5, Milliseconds))
+  )
+
+  describe("ScalaVirtualMachine for 2.11") {
+    it("should return the breakpointable line numbers for the file") {
+      val testClass = "org.senkbeil.test.misc.AvailableLines"
+
+      withVirtualMachine(testClass, suspend = false) { (_, scalaVirtualMachine) =>
+        // NOTE: In Scala 2.11, there is no breakpoint available on the object
+        //       itself (line 11), but there is one on the last line of the
+        //       object (72) - verified with IntelliJ
+        val expected = Seq(
+          12, 13, 14, 15, 16, 20, 21, 22, 26, 27, 28, 32, 34, 35, 37, 39,
+          40, 41, 42, 45, 46, 47, 50, 52, 53, 57, 58, 59, 60, 63, 65, 72
+        )
+
+        val file = scalaClassStringToFileString(testClass)
+
+        // There is some delay while receiving the Java classes that make up
+        // our file, so must wait for enough responses to get all of our lines
+        eventually {
+          val actual = scalaVirtualMachine.availableLinesForFile(file).get
+          actual should contain theSameElementsInOrderAs expected
+        }
+      }
+    }
+  }
+}

--- a/scala-debugger-api/src/it/scala/org/senkbeil/debugger/virtualmachines/ScalaVirtualMachineIntegrationSpec.scala
+++ b/scala-debugger-api/src/it/scala/org/senkbeil/debugger/virtualmachines/ScalaVirtualMachineIntegrationSpec.scala
@@ -61,28 +61,5 @@ class ScalaVirtualMachineIntegrationSpec extends FunSpec with Matchers
         }
       }
     }
-
-    it("should return the breakpointable line numbers for the file") {
-      val testClass = "org.senkbeil.test.misc.AvailableLines"
-
-      withVirtualMachine(testClass, suspend = false) { (_, scalaVirtualMachine) =>
-        // NOTE: This fails with Scala 2.11 as there is no line 11 but there
-        //       is a line 72 (is this influenced by how Scala translates to
-        //       Java?)
-        val expected = Seq(
-          11, 12, 13, 14, 15, 16, 20, 21, 22, 26, 27, 28, 32, 34, 35, 37, 39,
-          40, 41, 42, 45, 46, 47, 50, 52, 53, 57, 58, 59, 60, 63, 65
-        )
-
-        val file = scalaClassStringToFileString(testClass)
-
-        // There is some delay while receiving the Java classes that make up
-        // our file, so must wait for enough responses to get all of our lines
-        eventually {
-          val actual = scalaVirtualMachine.availableLinesForFile(file).get
-          actual should contain theSameElementsInOrderAs expected
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
Resolves #26.