### PR TITLE
Refactor suspend calls

### DIFF
--- a/scala-debugger-api/src/main/scala/org/senkbeil/debugger/api/breakpoints/BreakpointManager.scala
+++ b/scala-debugger-api/src/main/scala/org/senkbeil/debugger/api/breakpoints/BreakpointManager.scala
@@ -13,7 +13,7 @@ import com.sun.jdi.request.EventRequest
 
 import scala.collection.mutable
 import scala.collection.JavaConverters._
-import scala.util.{Failure, Success}
+import scala.util.{Try, Failure, Success}
 
 /**
  * Represents the manager for breakpoint requests.
@@ -150,7 +150,7 @@ class BreakpointManager(
     // TODO: Investigate what level of suspension we need (the entire VM?) and
     //       what code within this block actually needs the suspension
     // Create and enable breakpoints for all underlying locations
-    val result = suspendVirtualMachineAndExecute {
+    val result = Try {
       // Our key is using the class name and line number relevant to the
       // line breakpoint
       val key: BreakpointBundleKey = (fileName, lineNumber)
@@ -211,7 +211,7 @@ class BreakpointManager(
    */
   def removeLineBreakpoint(fileName: String, lineNumber: Int): Boolean = {
     // Remove breakpoints for all underlying locations
-    val result = suspendVirtualMachineAndExecute {
+    val result = Try {
       val key: BreakpointBundleKey = (fileName, lineNumber)
 
       val breakpointBundleToRemove = lineBreakpoints(key)

--- a/scala-debugger-api/src/test/scala/org/senkbeil/debugger/api/virtualmachines/ScalaVirtualMachineSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/senkbeil/debugger/api/virtualmachines/ScalaVirtualMachineSpec.scala
@@ -83,10 +83,10 @@ class ScalaVirtualMachineSpec extends FunSpec with Matchers
         val expected = new Throwable
 
         inSequence {
-          (mockVirtualMachine.suspend _).expects().once()
+          (mockMainThreadReference.suspend _).expects().once()
           (mockMainThreadReference.frames: Function0[java.util.List[StackFrame]])
             .expects().throwing(expected)
-          (mockVirtualMachine.resume _).expects().once()
+          (mockMainThreadReference.resume _).expects().once()
         }
 
         val actual = the [Throwable] thrownBy scalaVirtualMachine.mainClassName
@@ -115,10 +115,10 @@ class ScalaVirtualMachineSpec extends FunSpec with Matchers
         }
 
         // Set the main thread to return a stack frame with the main method
-        (mockVirtualMachine.suspend _).expects().once()
+        (mockMainThreadReference.suspend _).expects().once()
         (mockMainThreadReference.frames: Function0[java.util.List[StackFrame]])
           .expects().returning(Seq(mockStackFrame).asJava)
-        (mockVirtualMachine.resume _).expects().once()
+        (mockMainThreadReference.resume _).expects().once()
 
         // Should fail to find a location with a main method
         intercept[AssertionError] {
@@ -155,10 +155,10 @@ class ScalaVirtualMachineSpec extends FunSpec with Matchers
         }
 
         // Set the main thread to return a stack frame with the main method
-        (mockVirtualMachine.suspend _).expects().once()
+        (mockMainThreadReference.suspend _).expects().once()
         (mockMainThreadReference.frames: Function0[java.util.List[StackFrame]])
           .expects().returning(Seq(mockStackFrame).asJava)
-        (mockVirtualMachine.resume _).expects().once()
+        (mockMainThreadReference.resume _).expects().once()
 
         val actual = scalaVirtualMachine.mainClassName
 
@@ -201,10 +201,10 @@ class ScalaVirtualMachineSpec extends FunSpec with Matchers
         )
 
         // Set the main thread to return a stack frame with the main method
-        (mockVirtualMachine.suspend _).expects().once()
+        (mockMainThreadReference.suspend _).expects().once()
         (mockMainThreadReference.frames: Function0[java.util.List[StackFrame]])
           .expects().returning(mockStackFrames.asJava)
-        (mockVirtualMachine.resume _).expects().once()
+        (mockMainThreadReference.resume _).expects().once()
 
         val actual = scalaVirtualMachine.mainClassName
 
@@ -234,12 +234,10 @@ class ScalaVirtualMachineSpec extends FunSpec with Matchers
         val expected = new Throwable
 
         inSequence {
-          (mockVirtualMachine.suspend _).expects().once()
           (mockMainThreadReference.suspend _).expects().once()
           (mockMainThreadReference.frames: Function0[java.util.List[StackFrame]])
             .expects().throwing(expected)
           (mockMainThreadReference.resume _).expects().once()
-          (mockVirtualMachine.resume _).expects().once()
         }
 
         val actual = the [Throwable] thrownBy
@@ -270,12 +268,10 @@ class ScalaVirtualMachineSpec extends FunSpec with Matchers
 
         // Set the main thread to return a stack frame with the main method
         inSequence {
-          (mockVirtualMachine.suspend _).expects().once()
           (mockMainThreadReference.suspend _).expects().once()
           (mockMainThreadReference.frames: Function0[java.util.List[StackFrame]])
             .expects().returning(Seq(mockStackFrame).asJava)
           (mockMainThreadReference.resume _).expects().once()
-          (mockVirtualMachine.resume _).expects().once()
         }
 
         // Should fail to find a location with a main method
@@ -328,12 +324,10 @@ class ScalaVirtualMachineSpec extends FunSpec with Matchers
 
         // Set the main thread to return a stack frame with the main method
         inSequence {
-          (mockVirtualMachine.suspend _).expects().once()
           (mockMainThreadReference.suspend _).expects().once()
           (mockMainThreadReference.frames: Function0[java.util.List[StackFrame]])
             .expects().returning(Seq(mockStackFrame).asJava)
           (mockMainThreadReference.resume _).expects().once()
-          (mockVirtualMachine.resume _).expects().once()
         }
 
         val actual = scalaVirtualMachine.commandLineArguments


### PR DESCRIPTION
Resolves #14. Able to remove calls in breakpoint manager and change virtual machine suspension to main thread suspension in scala virtual machine main class and arguments retrieval methods.