### PR TITLE
Combine spec and test traits into a ParallelMockFunSpec abstract

### DIFF
--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/debuggers/AttachingDebuggerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/debuggers/AttachingDebuggerSpec.scala
@@ -11,8 +11,7 @@ import org.scaladebugger.api.virtualmachines.{ScalaVirtualMachine, StandardScala
 
 import scala.collection.JavaConverters._
 
-class AttachingDebuggerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class AttachingDebuggerSpec extends test.ParallelMockFunSpec
 {
   private def createConnectorArgumentMock(
     setter: Boolean = false,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/debuggers/LaunchingDebuggerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/debuggers/LaunchingDebuggerSpec.scala
@@ -11,8 +11,7 @@ import org.scaladebugger.api.virtualmachines.{ScalaVirtualMachine, StandardScala
 
 import scala.collection.JavaConverters._
 
-class LaunchingDebuggerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class LaunchingDebuggerSpec extends test.ParallelMockFunSpec
 {
   private def createConnectorArgumentMock(
     setter: Boolean = false,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/debuggers/ListeningDebuggerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/debuggers/ListeningDebuggerSpec.scala
@@ -14,8 +14,7 @@ import org.scaladebugger.api.virtualmachines.StandardScalaVirtualMachine
 
 import scala.collection.JavaConverters._
 
-class ListeningDebuggerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ListeningDebuggerSpec extends test.ParallelMockFunSpec
 {
   private def createConnectorArgumentMock(
     setter: Boolean = false,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/debuggers/ProcessDebuggerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/debuggers/ProcessDebuggerSpec.scala
@@ -11,8 +11,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.collection.JavaConverters._
 
-class ProcessDebuggerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ProcessDebuggerSpec extends test.ParallelMockFunSpec
 {
   private def createConnectorArgumentMock(
     setter: Boolean = false,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/breakpoints/BreakpointDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/breakpoints/BreakpointDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class BreakpointDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class BreakpointDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockBreakpointProfile = mock[BreakpointProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/classes/ClassPrepareDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/classes/ClassPrepareDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class ClassPrepareDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassPrepareDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockClassPrepareProfile = mock[ClassPrepareProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/classes/ClassUnloadDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/classes/ClassUnloadDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class ClassUnloadDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassUnloadDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockClassUnloadProfile = mock[ClassUnloadProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/events/EventDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/events/EventDSLWrapperSpec.scala
@@ -13,8 +13,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class EventDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class EventDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockEventProfile = mock[EventProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/exceptions/ExceptionDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/exceptions/ExceptionDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class ExceptionDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ExceptionDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockExceptionProfile = mock[ExceptionProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/FrameInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/FrameInfoDSLWrapperSpec.scala
@@ -8,8 +8,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.{Success, Try}
 
-class FrameInfoDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class FrameInfoDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   // NOTE: Cannot mock Function0 with no parentheses
   //private val mockFrameInfoProfile = mock[FrameInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/GrabInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/GrabInfoDSLWrapperSpec.scala
@@ -7,8 +7,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class GrabInfoDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class GrabInfoDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockGrabInfoProfile = mock[GrabInfoProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/ObjectInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/ObjectInfoDSLWrapperSpec.scala
@@ -11,8 +11,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class ObjectInfoDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ObjectInfoDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val TestUniqueId = 1234L
   private val mockObjectInfoProfile = mock[ObjectInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/ValueInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/ValueInfoDSLWrapperSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.virtualmachines.{ObjectCache, ScalaVirtualMachine}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class ValueInfoDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ValueInfoDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val TestUniqueId = 1234L
   private val mockObjectInfoProfile = mock[ObjectInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/VariableInfoDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/info/VariableInfoDSLWrapperSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.virtualmachines.{ObjectCache, ScalaVirtualMachine}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class VariableInfoDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VariableInfoDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val TestUniqueId = 1234L
   private val mockObjectInfoProfile = mock[ObjectInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/methods/MethodEntryDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/methods/MethodEntryDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class MethodEntryDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodEntryDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockMethodEntryProfile = mock[MethodEntryProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/methods/MethodExitDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/methods/MethodExitDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class MethodExitDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodExitDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockMethodExitProfile = mock[MethodExitProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/monitors/MonitorContendedEnterDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/monitors/MonitorContendedEnterDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class MonitorContendedEnterDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorContendedEnterDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockMonitorContendedEnterProfile = mock[MonitorContendedEnterProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/monitors/MonitorContendedEnteredDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/monitors/MonitorContendedEnteredDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class MonitorContendedEnteredDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorContendedEnteredDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockMonitorContendedEnteredProfile = mock[MonitorContendedEnteredProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/monitors/MonitorWaitDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/monitors/MonitorWaitDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class MonitorWaitDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorWaitDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockMonitorWaitProfile = mock[MonitorWaitProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/monitors/MonitorWaitedDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/monitors/MonitorWaitedDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class MonitorWaitedDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorWaitedDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockMonitorWaitedProfile = mock[MonitorWaitedProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/steps/StepDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/steps/StepDSLWrapperSpec.scala
@@ -11,8 +11,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class StepDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class StepDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockStepProfile = mock[StepProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/threads/ThreadDeathDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/threads/ThreadDeathDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class ThreadDeathDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadDeathDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockThreadDeathProfile = mock[ThreadDeathProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/threads/ThreadStartDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/threads/ThreadStartDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class ThreadStartDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadStartDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockThreadStartProfile = mock[ThreadStartProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/vm/VMDeathDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/vm/VMDeathDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class VMDeathDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VMDeathDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockVMDeathProfile = mock[VMDeathProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/vm/VMDisconnectDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/vm/VMDisconnectDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class VMDisconnectDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VMDisconnectDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockVMDisconnectProfile = mock[VMDisconnectProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/vm/VMStartDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/vm/VMStartDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class VMStartDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VMStartDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockVMStartProfile = mock[VMStartProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/watchpoints/AccessWatchpointDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/watchpoints/AccessWatchpointDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class AccessWatchpointDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class AccessWatchpointDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockAccessWatchpointProfile = mock[AccessWatchpointProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/watchpoints/ModificationWatchpointDSLWrapperSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/dsl/watchpoints/ModificationWatchpointDSLWrapperSpec.scala
@@ -10,8 +10,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.Success
 
-class ModificationWatchpointDSLWrapperSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ModificationWatchpointDSLWrapperSpec extends test.ParallelMockFunSpec
 {
   private val mockModificationWatchpointProfile = mock[ModificationWatchpointProfile]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/breakpoints/BreakpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/breakpoints/BreakpointManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestBreakpointManager
 
 import scala.util.Success
 
-class BreakpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class BreakpointManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockBreakpointManager = mock[BreakpointManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/breakpoints/DummyBreakpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/breakpoints/DummyBreakpointManagerSpec.scala
@@ -6,8 +6,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 import test.JDIMockHelpers
 
-class DummyBreakpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class DummyBreakpointManagerSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val breakpointManager = new DummyBreakpointManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/breakpoints/PendingBreakpointSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/breakpoints/PendingBreakpointSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestBreakpointManager}
 
 import scala.util.{Failure, Success}
 
-class PendingBreakpointSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingBreakpointSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockBreakpointManager = mock[BreakpointManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/breakpoints/StandardBreakpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/breakpoints/StandardBreakpointManagerSpec.scala
@@ -12,8 +12,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Success, Failure}
 
-class StandardBreakpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class StandardBreakpointManagerSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/ClassPrepareManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/ClassPrepareManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestClassPrepareManager
 
 import scala.util.Success
 
-class ClassPrepareManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassPrepareManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockClassPrepareManager = mock[ClassPrepareManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/ClassUnloadManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/ClassUnloadManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestClassUnloadManager
 
 import scala.util.Success
 
-class ClassUnloadManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassUnloadManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockClassUnloadManager = mock[ClassUnloadManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/DummyClassPrepareManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/DummyClassPrepareManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyClassPrepareManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyClassPrepareManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val classPrepareManager = new DummyClassPrepareManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/DummyClassUnloadManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/DummyClassUnloadManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyClassUnloadManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyClassUnloadManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val classUnloadManager = new DummyClassUnloadManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/PendingClassPrepareSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/PendingClassPrepareSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestClassPrepareManager}
 
 import scala.util.{Failure, Success}
 
-class PendingClassPrepareSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingClassPrepareSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockClassPrepareManager = mock[ClassPrepareManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/PendingClassUnloadSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/PendingClassUnloadSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestClassUnloadManager}
 
 import scala.util.{Failure, Success}
 
-class PendingClassUnloadSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingClassUnloadSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockClassUnloadManager = mock[ClassUnloadManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/StandardClassPrepareManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/StandardClassPrepareManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestArgument, JDIRequestPr
 
 import scala.util.{Failure, Success}
 
-class StandardClassPrepareManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardClassPrepareManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/StandardClassUnloadManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/classes/StandardClassUnloadManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestArgument, JDIRequestPr
 
 import scala.util.{Failure, Success}
 
-class StandardClassUnloadManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardClassUnloadManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/DummyEventManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/DummyEventManagerSpec.scala
@@ -6,8 +6,7 @@ import org.scalatest.{ParallelTestExecution, Matchers, FunSpec}
 import org.scaladebugger.api.lowlevel.events.EventManager.EventHandler
 import org.scaladebugger.api.lowlevel.events.EventType.EventType
 
-class DummyEventManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class DummyEventManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestHandlerId = java.util.UUID.randomUUID().toString
   private val eventManager = new DummyEventManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/EventManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/EventManagerSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.lowlevel.events.EventType.EventType
 import org.scaladebugger.api.lowlevel.events.data.{JDIEventDataResult, JDIEventDataRequest}
 import test.TestEventManager
 
-class EventManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class EventManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestHandlerId = java.util.UUID.randomUUID().toString
   private val mockEventManager = mock[EventManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/JDIEventArgumentProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/JDIEventArgumentProcessorSpec.scala
@@ -7,8 +7,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.data.{JDIEventDataProcessor, JDIEventDataRequest, JDIEventDataResult, JDIEventDataUnknownError}
 import org.scaladebugger.api.lowlevel.events.filters.{JDIEventFilter, JDIEventFilterProcessor}
 
-class JDIEventArgumentProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class JDIEventArgumentProcessorSpec extends test.ParallelMockFunSpec
 {
   describe("JDIEventArgumentProcessor") {
     describe("#processAll") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/PendingEventHandlerSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/PendingEventHandlerSupportSpec.scala
@@ -8,8 +8,7 @@ import org.scaladebugger.api.lowlevel.events.EventType.EventType
 import org.scaladebugger.api.utils.{ActionInfo, PendingActionManager}
 import test.{JDIMockHelpers, TestEventManager}
 
-class PendingEventHandlerSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingEventHandlerSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestHandlerId = java.util.UUID.randomUUID().toString
   private val mockEventManager = mock[EventManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/StandardEventManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/StandardEventManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.utils.LoopingTaskRunner
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class StandardEventManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardEventManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestHandlerId = java.util.UUID.randomUUID().toString
   private val mockEventQueue = mock[EventQueue]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/data/processors/CustomPropertyDataRequestProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/data/processors/CustomPropertyDataRequestProcessorSpec.scala
@@ -8,8 +8,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.data.requests.CustomPropertyDataRequest
 import org.scaladebugger.api.lowlevel.events.data.results.CustomPropertyDataResult
 
-class CustomPropertyDataRequestProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class CustomPropertyDataRequestProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testKey = "some key"
   private val testValue = "some value"

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/data/requests/CustomPropertyDataRequestSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/data/requests/CustomPropertyDataRequestSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class CustomPropertyDataRequestSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class CustomPropertyDataRequestSpec extends test.ParallelMockFunSpec
 {
   private val testKey = "some key"
   private val customPropertyDataRequest =

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/AndFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/AndFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class AndFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class AndFilterSpec extends test.ParallelMockFunSpec
 {
   private val andFilter = AndFilter()
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/CustomPropertyFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/CustomPropertyFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class CustomPropertyFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class CustomPropertyFilterSpec extends test.ParallelMockFunSpec
 {
   private val testKey = "some key"
   private val testValue = "some value"

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/MaxTriggerFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/MaxTriggerFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ParallelTestExecution, Matchers, FunSpec}
 
-class MaxTriggerFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MaxTriggerFilterSpec extends test.ParallelMockFunSpec
 {
   private val testCount = 3
   private val maxTriggerFilter = MaxTriggerFilter(count = testCount)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/MethodNameFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/MethodNameFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class MethodNameFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodNameFilterSpec extends test.ParallelMockFunSpec
 {
   private val testName = "some name"
   private val methodNameFilter = MethodNameFilter(name = testName)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/MinTriggerFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/MinTriggerFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class MinTriggerFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MinTriggerFilterSpec extends test.ParallelMockFunSpec
 {
   private val testCount = 3
   private val minTriggerFilter = MinTriggerFilter(count = testCount)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/NotFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/NotFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class NotFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class NotFilterSpec extends test.ParallelMockFunSpec
 {
   private val notFilter = NotFilter(mock[JDIEventFilter])
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/OrFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/OrFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class OrFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class OrFilterSpec extends test.ParallelMockFunSpec
 {
   private val orFilter = OrFilter()
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/UniqueIdPropertyFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/UniqueIdPropertyFilterSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.filters.processors.CustomPropertyFilterProcessor
 
-class UniqueIdPropertyFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class UniqueIdPropertyFilterSpec extends test.ParallelMockFunSpec
 {
   private val testId = java.util.UUID.randomUUID().toString
   private val uniqueIdPropertyFilter = UniqueIdPropertyFilter(id = testId)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/WildcardPatternFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/WildcardPatternFilterSpec.scala
@@ -3,8 +3,7 @@ package org.scaladebugger.api.lowlevel.events.filters
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class WildcardPatternFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class WildcardPatternFilterSpec extends test.ParallelMockFunSpec
 {
   private val testPattern = "some*pattern"
   private val wildcardPatternFilter = WildcardPatternFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/AndFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/AndFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.filters.{JDIEventFilter, JDIEventFilterProcessor, AndFilter}
 
-class AndFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class AndFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   describe("AndFilterProcessor") {
     describe("#process") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/CustomPropertyFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/CustomPropertyFilterProcessorSpec.scala
@@ -7,8 +7,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.filters.CustomPropertyFilter
 
-class CustomPropertyFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class CustomPropertyFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testKey = "some key"
   private val testValue = "some value"

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/MaxTriggerFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/MaxTriggerFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.filters.MaxTriggerFilter
 
-class MaxTriggerFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MaxTriggerFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testCount = 3
   private val maxTriggerFilter = MaxTriggerFilter(count = testCount)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/MethodNameFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/MethodNameFilterProcessorSpec.scala
@@ -7,8 +7,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.filters.MethodNameFilter
 
-class MethodNameFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodNameFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testName = "some name"
   private val methodNameFilter = MethodNameFilter(name = testName)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/MinTriggerFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/MinTriggerFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.filters.MinTriggerFilter
 
-class MinTriggerFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MinTriggerFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testCount = 3
   private val minTriggerFilter = MinTriggerFilter(count = testCount)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/NotFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/NotFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.filters.{NotFilter, JDIEventFilter, JDIEventFilterProcessor}
 
-class NotFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class NotFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   describe("NotFilterProcessor") {
     describe("#process") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/OrFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/OrFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.events.filters.{OrFilter, JDIEventFilter, JDIEventFilterProcessor}
 
-class OrFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class OrFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   describe("OrFilterProcessor") {
     describe("#process") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/WildcardPatternFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/filters/processors/WildcardPatternFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.lowlevel.events.filters.WildcardPatternFilter
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class WildcardPatternFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class WildcardPatternFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testPattern = "some*pattern"
   private val wildcardPatternFilter = WildcardPatternFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/misc/NoResumeSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/misc/NoResumeSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ParallelTestExecution, Matchers, FunSpec}
 
-class NoResumeSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class NoResumeSpec extends test.ParallelMockFunSpec
 {
   describe("NoResume") {
     describe("#value") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/misc/YesResumeSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/misc/YesResumeSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class YesResumeSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class YesResumeSpec extends test.ParallelMockFunSpec
 {
   describe("YesResume") {
     describe("#value") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/misc/processors/ResumeProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/events/misc/processors/ResumeProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.lowlevel.events.misc.{NoResume, YesResume}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ParallelTestExecution, Matchers, FunSpec}
 
-class ResumeProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ResumeProcessorSpec extends test.ParallelMockFunSpec
 {
   describe("ResumeProcessor") {
     describe("#process") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/exceptions/DummyExceptionManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/exceptions/DummyExceptionManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.DummyOperationException
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success}
 
-class DummyExceptionManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyExceptionManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val exceptionManager = new DummyExceptionManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/exceptions/ExceptionManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/exceptions/ExceptionManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestExceptionManager
 
 import scala.util.Success
 
-class ExceptionManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ExceptionManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockExceptionManager = mock[ExceptionManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/exceptions/PendingExceptionSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/exceptions/PendingExceptionSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestExceptionManager}
 
 import scala.util.{Failure, Success}
 
-class PendingExceptionSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingExceptionSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockExceptionManager = mock[ExceptionManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/exceptions/StandardExceptionManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/exceptions/StandardExceptionManagerSpec.scala
@@ -8,8 +8,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success}
 
-class StandardExceptionManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardExceptionManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockReferenceType = mock[ReferenceType]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/DummyMethodEntryManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/DummyMethodEntryManagerSpec.scala
@@ -8,8 +8,7 @@ import org.scaladebugger.api.lowlevel.DummyOperationException
 
 import scala.util.{Failure, Success}
 
-class DummyMethodEntryManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyMethodEntryManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val methodEntryManager = new DummyMethodEntryManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/DummyMethodExitManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/DummyMethodExitManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyMethodExitManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyMethodExitManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val methodExitManager = new DummyMethodExitManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/MethodEntryManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/MethodEntryManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestMethodEntryManager
 
 import scala.util.Success
 
-class MethodEntryManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodEntryManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMethodEntryManager = mock[MethodEntryManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/MethodExitManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/MethodExitManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestMethodExitManager
 
 import scala.util.Success
 
-class MethodExitManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodExitManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMethodExitManager = mock[MethodExitManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/PendingMethodEntrySupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/PendingMethodEntrySupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestMethodEntryManager}
 
 import scala.util.{Failure, Success}
 
-class PendingMethodEntrySupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingMethodEntrySupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMethodEntryManager = mock[MethodEntryManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/PendingMethodExitSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/PendingMethodExitSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestMethodExitManager}
 
 import scala.util.{Failure, Success}
 
-class PendingMethodExitSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingMethodExitSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMethodExitManager = mock[MethodExitManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/StandardMethodEntryManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/StandardMethodEntryManagerSpec.scala
@@ -7,8 +7,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.{Failure, Success}
 
-class StandardMethodEntryManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardMethodEntryManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/StandardMethodExitManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/methods/StandardMethodExitManagerSpec.scala
@@ -7,8 +7,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
 import scala.util.{Failure, Success}
 
-class StandardMethodExitManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardMethodExitManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/DummyMonitorContendedEnterManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/DummyMonitorContendedEnterManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyMonitorContendedEnterManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyMonitorContendedEnterManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val monitorContendedEnterManager = new DummyMonitorContendedEnterManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/DummyMonitorContendedEnteredManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/DummyMonitorContendedEnteredManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyMonitorContendedEnteredManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyMonitorContendedEnteredManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val monitorContendedEnteredManager = new DummyMonitorContendedEnteredManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/DummyMonitorWaitManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/DummyMonitorWaitManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyMonitorWaitManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyMonitorWaitManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val monitorWaitManager = new DummyMonitorWaitManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/DummyMonitorWaitedManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/DummyMonitorWaitedManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyMonitorWaitedManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyMonitorWaitedManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val monitorWaitedManager = new DummyMonitorWaitedManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/MonitorContendedEnterManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/MonitorContendedEnterManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestMonitorContendedEnterManager
 
 import scala.util.Success
 
-class MonitorContendedEnterManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorContendedEnterManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMonitorContendedEnterManager = mock[MonitorContendedEnterManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/MonitorContendedEnteredManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/MonitorContendedEnteredManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestMonitorContendedEnteredManager
 
 import scala.util.Success
 
-class MonitorContendedEnteredManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorContendedEnteredManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMonitorContendedEnteredManager = mock[MonitorContendedEnteredManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/MonitorWaitManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/MonitorWaitManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestMonitorWaitManager
 
 import scala.util.Success
 
-class MonitorWaitManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorWaitManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMonitorWaitManager = mock[MonitorWaitManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/MonitorWaitedManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/MonitorWaitedManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestMonitorWaitedManager
 
 import scala.util.Success
 
-class MonitorWaitedManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorWaitedManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMonitorWaitedManager = mock[MonitorWaitedManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/PendingMonitorContendedEnterSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/PendingMonitorContendedEnterSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestMonitorContendedEnterManager}
 
 import scala.util.{Failure, Success}
 
-class PendingMonitorContendedEnterSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingMonitorContendedEnterSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMonitorContendedEnterManager = mock[MonitorContendedEnterManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/PendingMonitorContendedEnteredSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/PendingMonitorContendedEnteredSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestMonitorContendedEnteredManager}
 
 import scala.util.{Failure, Success}
 
-class PendingMonitorContendedEnteredSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingMonitorContendedEnteredSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMonitorContendedEnteredManager = mock[MonitorContendedEnteredManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/PendingMonitorWaitSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/PendingMonitorWaitSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestMonitorWaitManager}
 
 import scala.util.{Failure, Success}
 
-class PendingMonitorWaitSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingMonitorWaitSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMonitorWaitManager = mock[MonitorWaitManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/PendingMonitorWaitedSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/PendingMonitorWaitedSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestMonitorWaitedManager}
 
 import scala.util.{Failure, Success}
 
-class PendingMonitorWaitedSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingMonitorWaitedSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockMonitorWaitedManager = mock[MonitorWaitedManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/StandardMonitorContendedEnterManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/StandardMonitorContendedEnterManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestArgument, JDIRequestPr
 
 import scala.util.{Failure, Success}
 
-class StandardMonitorContendedEnterManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardMonitorContendedEnterManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/StandardMonitorContendedEnteredManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/StandardMonitorContendedEnteredManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestArgument, JDIRequestPr
 
 import scala.util.{Failure, Success}
 
-class StandardMonitorContendedEnteredManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardMonitorContendedEnteredManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/StandardMonitorWaitManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/StandardMonitorWaitManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestArgument, JDIRequestPr
 
 import scala.util.{Failure, Success}
 
-class StandardMonitorWaitManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardMonitorWaitManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/StandardMonitorWaitedManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/monitors/StandardMonitorWaitedManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestArgument, JDIRequestPr
 
 import scala.util.{Failure, Success}
 
-class StandardMonitorWaitedManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardMonitorWaitedManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/JDIRequestArgumentProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/JDIRequestArgumentProcessorSpec.scala
@@ -8,8 +8,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.filters._
 import org.scaladebugger.api.lowlevel.requests.properties.{CustomProperty, EnabledProperty, SuspendPolicyProperty}
 
-class JDIRequestArgumentProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class JDIRequestArgumentProcessorSpec extends test.ParallelMockFunSpec
 {
   // Create three mock filters to provide to the main filter processor
   private val mockArgumentsAndProcessors = Seq(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/ClassExclusionFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/ClassExclusionFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class ClassExclusionFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassExclusionFilterSpec extends test.ParallelMockFunSpec
 {
   private val testPattern = "some pattern"
   private val classExclusionFilter = ClassExclusionFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/ClassInclusionFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/ClassInclusionFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class ClassInclusionFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassInclusionFilterSpec extends test.ParallelMockFunSpec
 {
   private val testPattern = "some pattern"
   private val classInclusionFilter = ClassInclusionFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/ClassReferenceFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/ClassReferenceFilterSpec.scala
@@ -5,8 +5,7 @@ import com.sun.jdi.ReferenceType
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class ClassReferenceFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassReferenceFilterSpec extends test.ParallelMockFunSpec
 {
   private val mockReferenceType = mock[ReferenceType]
   private val classReferenceFilter = ClassReferenceFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/CountFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/CountFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class CountFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class CountFilterSpec extends test.ParallelMockFunSpec
 {
   private val testCount = 3
   private val countFilter = CountFilter(count = testCount)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/InstanceFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/InstanceFilterSpec.scala
@@ -5,8 +5,7 @@ import com.sun.jdi.ObjectReference
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class InstanceFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class InstanceFilterSpec extends test.ParallelMockFunSpec
 {
   private val mockObjectReference = mock[ObjectReference]
   private val instanceFilter = InstanceFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/SourceNameFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/SourceNameFilterSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ParallelTestExecution, FunSpec, Matchers}
 
-class SourceNameFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SourceNameFilterSpec extends test.ParallelMockFunSpec
 {
   private val testPattern = "some pattern"
   private val sourceNameFilter = SourceNameFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/ThreadFilterSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/ThreadFilterSpec.scala
@@ -5,8 +5,7 @@ import com.sun.jdi.ThreadReference
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class ThreadFilterSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadFilterSpec extends test.ParallelMockFunSpec
 {
   private val mockThreadReference = mock[ThreadReference]
   private val threadFilter = ThreadFilter(threadReference = mockThreadReference)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/ClassExclusionFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/ClassExclusionFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.filters.ClassExclusionFilter
 
-class ClassExclusionFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassExclusionFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testPattern = "some pattern"
   private val classExclusionFilter = ClassExclusionFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/ClassInclusionFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/ClassInclusionFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.filters.ClassInclusionFilter
 
-class ClassInclusionFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassInclusionFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testPattern = "some pattern"
   private val classInclusionFilter = ClassInclusionFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/ClassReferenceFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/ClassReferenceFilterProcessorSpec.scala
@@ -7,8 +7,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.filters.ClassReferenceFilter
 
-class ClassReferenceFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassReferenceFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val mockReferenceType = mock[ReferenceType]
   private val classReferenceFilter = ClassReferenceFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/CountFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/CountFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.filters.CountFilter
 
-class CountFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class CountFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testCount = 3
   private val countFilter = CountFilter(count = testCount)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/InstanceFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/InstanceFilterProcessorSpec.scala
@@ -7,8 +7,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.filters.InstanceFilter
 
-class InstanceFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class InstanceFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val mockObjectReference = mock[ObjectReference]
   private val instanceFilter = InstanceFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/SourceNameFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/SourceNameFilterProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.filters.SourceNameFilter
 
-class SourceNameFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SourceNameFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testSourceNamePattern = "some pattern"
   private val sourceNameFilter = SourceNameFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/ThreadFilterProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/filters/processors/ThreadFilterProcessorSpec.scala
@@ -7,8 +7,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.filters.ThreadFilter
 
-class ThreadFilterProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadFilterProcessorSpec extends test.ParallelMockFunSpec
 {
   private val mockThreadReference = mock[ThreadReference]
   private val threadFilter = ThreadFilter(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/CustomPropertySpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/CustomPropertySpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class CustomPropertySpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class CustomPropertySpec extends test.ParallelMockFunSpec
 {
   private val mockKey = mock[AnyRef]
   private val mockValue = mock[AnyRef]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/EnabledPropertySpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/EnabledPropertySpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class EnabledPropertySpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class EnabledPropertySpec extends test.ParallelMockFunSpec
 {
   private val testValue = false
   private val enabledProperty = EnabledProperty(value = testValue)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/SuspendPolicyPropertySpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/SuspendPolicyPropertySpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class SuspendPolicyPropertySpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SuspendPolicyPropertySpec extends test.ParallelMockFunSpec
 {
   private val testPolicy = 0
   private val suspendPolicyProperty = SuspendPolicyProperty(policy = testPolicy)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/UniqueIdPropertySpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/UniqueIdPropertySpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.properties.processors.CustomPropertyProcessor
 
-class UniqueIdPropertySpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class UniqueIdPropertySpec extends test.ParallelMockFunSpec
 {
   private val testId = java.util.UUID.randomUUID().toString
   private val uniqueIdProperty = UniqueIdProperty(id = testId)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/processors/CustomPropertyProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/processors/CustomPropertyProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.properties.CustomProperty
 
-class CustomPropertyProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class CustomPropertyProcessorSpec extends test.ParallelMockFunSpec
 {
   private val mockKey = mock[AnyRef]
   private val mockValue = mock[AnyRef]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/processors/EnabledPropertyProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/processors/EnabledPropertyProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.properties.EnabledProperty
 
-class EnabledPropertyProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class EnabledPropertyProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testValue = false
   private val enabledProperty = EnabledProperty(value = testValue)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/processors/SuspendPolicyPropertyProcessorSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/requests/properties/processors/SuspendPolicyPropertyProcessorSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.requests.properties.SuspendPolicyProperty
 
-class SuspendPolicyPropertyProcessorSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SuspendPolicyPropertyProcessorSpec extends test.ParallelMockFunSpec
 {
   private val testPolicy = 0
   private val suspendPolicyProperty = SuspendPolicyProperty(policy = testPolicy)

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/steps/DummyStepManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/steps/DummyStepManagerSpec.scala
@@ -10,8 +10,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class DummyStepManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class DummyStepManagerSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val stepManager = new DummyStepManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/steps/PendingStepSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/steps/PendingStepSupportSpec.scala
@@ -10,8 +10,7 @@ import test.{JDIMockHelpers, TestStepManager}
 
 import scala.util.{Try, Failure, Success}
 
-class PendingStepSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingStepSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockStepManager = mock[StepManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/steps/StandardStepManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/steps/StandardStepManagerSpec.scala
@@ -9,8 +9,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class StandardStepManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class StandardStepManagerSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockThreadReference = mock[ThreadReference]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/steps/StepManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/steps/StepManagerSpec.scala
@@ -9,8 +9,7 @@ import test.TestStepManager
 
 import scala.util.{Try, Success}
 
-class StepManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class StepManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockStepManager = mock[StepManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/DummyThreadDeathManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/DummyThreadDeathManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyThreadDeathManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyThreadDeathManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val threadDeathManager = new DummyThreadDeathManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/DummyThreadStartManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/DummyThreadStartManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyThreadStartManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyThreadStartManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val threadStartManager = new DummyThreadStartManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/PendingThreadDeathSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/PendingThreadDeathSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestThreadDeathManager}
 
 import scala.util.{Failure, Success}
 
-class PendingThreadDeathSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingThreadDeathSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockThreadDeathManager = mock[ThreadDeathManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/PendingThreadStartSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/PendingThreadStartSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestThreadStartManager}
 
 import scala.util.{Failure, Success}
 
-class PendingThreadStartSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingThreadStartSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockThreadStartManager = mock[ThreadStartManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/StandardThreadDeathManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/StandardThreadDeathManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestProcessor, JDIRequestA
 
 import scala.util.{Failure, Success}
 
-class StandardThreadDeathManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardThreadDeathManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/StandardThreadStartManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/StandardThreadStartManagerSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestProcessor, JDIRequestA
 
 import scala.util.{Failure, Success}
 
-class StandardThreadStartManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardThreadStartManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/ThreadDeathManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/ThreadDeathManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestThreadDeathManager
 
 import scala.util.Success
 
-class ThreadDeathManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadDeathManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockThreadDeathManager = mock[ThreadDeathManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/ThreadStartManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/threads/ThreadStartManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestThreadStartManager
 
 import scala.util.Success
 
-class ThreadStartManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadStartManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockThreadStartManager = mock[ThreadStartManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/utils/JDIArgumentGroupSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/utils/JDIArgumentGroupSpec.scala
@@ -7,8 +7,7 @@ import org.scaladebugger.api.lowlevel.JDIArgument
 import org.scaladebugger.api.lowlevel.events.JDIEventArgument
 import org.scaladebugger.api.lowlevel.requests.JDIRequestArgument
 
-class JDIArgumentGroupSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class JDIArgumentGroupSpec extends test.ParallelMockFunSpec
 {
   describe("JDIArgumentGroup") {
     describe("#apply") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/utils/JDIHelperMethodsSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/utils/JDIHelperMethodsSpec.scala
@@ -8,8 +8,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
-class JDIHelperMethodsSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class JDIHelperMethodsSpec extends test.ParallelMockFunSpec
 {
   private val mockReferenceType = mock[ReferenceType]
   private val mockThreadReference = mock[ThreadReference]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/vm/DummyVMDeathManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/vm/DummyVMDeathManagerSpec.scala
@@ -5,8 +5,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 
-class DummyVMDeathManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class DummyVMDeathManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val vmDeathManager = new DummyVMDeathManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/vm/PendingVMDeathSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/vm/PendingVMDeathSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestVMDeathManager}
 
 import scala.util.{Failure, Success}
 
-class PendingVMDeathSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingVMDeathSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockVMDeathManager = mock[VMDeathManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/vm/StandardVMDeathManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/vm/StandardVMDeathManagerSpec.scala
@@ -11,8 +11,7 @@ import org.scaladebugger.api.lowlevel.requests.{JDIRequestArgument, JDIRequestPr
 
 import scala.util.{Failure, Success}
 
-class StandardVMDeathManagerSpec extends FunSpec with Matchers with MockFactory
-  with ParallelTestExecution with org.scalamock.matchers.Matchers
+class StandardVMDeathManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/vm/VMDeathManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/vm/VMDeathManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestVMDeathManager
 
 import scala.util.Success
 
-class VMDeathManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VMDeathManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockVMDeathManager = mock[VMDeathManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/AccessWatchpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/AccessWatchpointManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestAccessWatchpointManager
 
 import scala.util.Success
 
-class AccessWatchpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class AccessWatchpointManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockAccessWatchpointManager = mock[AccessWatchpointManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/DummyAccessWatchpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/DummyAccessWatchpointManagerSpec.scala
@@ -6,8 +6,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 import test.JDIMockHelpers
 
-class DummyAccessWatchpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class DummyAccessWatchpointManagerSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val accessWatchpointManager = new DummyAccessWatchpointManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/DummyModificationWatchpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/DummyModificationWatchpointManagerSpec.scala
@@ -6,8 +6,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.DummyOperationException
 import test.JDIMockHelpers
 
-class DummyModificationWatchpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class DummyModificationWatchpointManagerSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val modificationWatchpointManager = new DummyModificationWatchpointManager

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/ModificationWatchpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/ModificationWatchpointManagerSpec.scala
@@ -8,8 +8,7 @@ import test.TestModificationWatchpointManager
 
 import scala.util.Success
 
-class ModificationWatchpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ModificationWatchpointManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockModificationWatchpointManager = mock[ModificationWatchpointManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/PendingAccessWatchpointSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/PendingAccessWatchpointSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestAccessWatchpointManager}
 
 import scala.util.{Failure, Success}
 
-class PendingAccessWatchpointSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingAccessWatchpointSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockAccessWatchpointManager = mock[AccessWatchpointManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/PendingModificationWatchpointSupportSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/PendingModificationWatchpointSupportSpec.scala
@@ -9,8 +9,7 @@ import test.{JDIMockHelpers, TestModificationWatchpointManager}
 
 import scala.util.{Failure, Success}
 
-class PendingModificationWatchpointSupportSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PendingModificationWatchpointSupportSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockModificationWatchpointManager = mock[ModificationWatchpointManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/StandardAccessWatchpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/StandardAccessWatchpointManagerSpec.scala
@@ -11,8 +11,7 @@ import scala.collection.JavaConverters._
 
 import scala.util.{Failure, Success}
 
-class StandardAccessWatchpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class StandardAccessWatchpointManagerSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/StandardModificationWatchpointManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/lowlevel/watchpoints/StandardModificationWatchpointManagerSpec.scala
@@ -11,8 +11,7 @@ import test.JDIMockHelpers
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success}
 
-class StandardModificationWatchpointManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class StandardModificationWatchpointManagerSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockEventRequestManager = mock[EventRequestManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/breakpoints/PureBreakpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/breakpoints/PureBreakpointProfileSpec.scala
@@ -19,8 +19,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class PureBreakpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureBreakpointProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val stubClassManager = stub[ClassManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/events/PureEventProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/events/PureEventProfileSpec.scala
@@ -12,8 +12,7 @@ import test.JDIMockHelpers
 
 import scala.util.Success
 
-class PureEventProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureEventProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestEventHandlerId = java.util.UUID.randomUUID().toString
   private val mockEventManager = mock[EventManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/exceptions/PureExceptionProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/exceptions/PureExceptionProfileSpec.scala
@@ -17,8 +17,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class PureExceptionProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureExceptionProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val mockExceptionManager = mock[ExceptionManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureArrayInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureArrayInfoProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import test.InfoTestClasses.{TestCreateInfoProfileTrait, TestMiscInfoProfileTrait}
 
-class PureArrayInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureArrayInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureArrayTypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureArrayTypeInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureArrayTypeInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureArrayTypeInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockNewArrayProfile = mockFunction[ArrayReference, ArrayInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassLoaderInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassLoaderInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureClassLoaderInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureClassLoaderInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassObjectInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassObjectInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureClassObjectInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureClassObjectInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassTypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureClassTypeInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureClassTypeInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureClassTypeInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockNewObjectProfile = mockFunction[ObjectReference, VirtualMachine, ObjectInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureCreateInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureCreateInfoProfileSpec.scala
@@ -10,8 +10,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class PureCreateInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureCreateInfoProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockInfoProducerProfile = mock[InfoProducerProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureFieldInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import test.InfoTestClasses.TestMiscInfoProfileTrait
 
-class PureFieldInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureFieldInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureFrameInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureFrameInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureFrameInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureFrameInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewLocalVariableProfile = mockFunction[LocalVariable, Int, IndexedVariableInfoProfile]
   private val mockNewObjectProfile = mockFunction[ObjectReference, ObjectInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureGrabInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureGrabInfoProfileSpec.scala
@@ -8,8 +8,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureGrabInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureGrabInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewObjectProfile = mockFunction[ObjectReference, ObjectInfoProfile]
   private val mockNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureInterfaceTypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureInterfaceTypeInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureInterfaceTypeInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureInterfaceTypeInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewInterfaceTypeProfile = mockFunction[InterfaceType, InterfaceTypeInfoProfile]
   private val mockNewClassTypeProfile = mockFunction[ClassType, ClassTypeInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocalVariableInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import test.InfoTestClasses.TestMiscInfoProfileTrait
 
-class PureLocalVariableInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureLocalVariableInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocationInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureLocationInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureLocationInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureLocationInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewMethodProfile = mockFunction[Method, MethodInfoProfile]
   private val mockNewReferenceTypeProfile = mockFunction[ReferenceType, ReferenceTypeInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMethodInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMethodInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureMethodInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureMethodInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureMiscInfoProfileSpec.scala
@@ -10,8 +10,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class PureMiscInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureMiscInfoProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockInfoProducerProfile = mock[InfoProducerProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureObjectInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureObjectInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureObjectInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureObjectInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewFieldProfile = mockFunction[Field, Int, FieldVariableInfoProfile]
   private val mockNewMethodProfile = mockFunction[Method, MethodInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PurePrimitiveInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PurePrimitiveInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PurePrimitiveInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PurePrimitiveInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockInfoProducerProfile = mock[InfoProducerProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PurePrimitiveTypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PurePrimitiveTypeInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PurePrimitiveTypeInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PurePrimitiveTypeInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockInfoProducerProfile = mock[InfoProducerProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureReferenceTypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureReferenceTypeInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureReferenceTypeInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureReferenceTypeInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewFieldProfile = mockFunction[Field, Int, FieldVariableInfoProfile]
   private val mockNewMethodProfile = mockFunction[Method, MethodInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureStringInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureStringInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureStringInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureStringInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureThreadGroupInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureThreadGroupInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureThreadGroupInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureThreadGroupInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewThreadGroupProfile = mockFunction[ThreadGroupReference, ThreadGroupInfoProfile]
   private val mockNewThreadProfile = mockFunction[ThreadReference, ThreadInfoProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureThreadInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureThreadInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureThreadInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureThreadInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockInfoProducerProfile = mock[InfoProducerProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureThreadStatusInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureThreadStatusInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureThreadStatusInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureThreadStatusInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockThreadReference = mock[ThreadReference]
   private val pureThreadStatusInfoProfile =

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureTypeCheckerProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureTypeCheckerProfileSpec.scala
@@ -5,8 +5,7 @@ import org.scaladebugger.api.profiles.traits.info.{MethodInfoProfile, ValueInfoP
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureTypeCheckerProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureTypeCheckerProfileSpec extends test.ParallelMockFunSpec
 {
   private val pureTypeCheckerProfile = new PureTypeCheckerProfile
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureTypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureTypeInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureTypeInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureTypeInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockInfoProducerProfile = mock[InfoProducerProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureValueInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/info/PureValueInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class PureValueInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PureValueInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]
   private val mockInfoProducerProfile = mock[InfoProducerProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/steps/PureStepProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/steps/PureStepProfileSpec.scala
@@ -17,8 +17,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class PureStepProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers with Futures
+class PureStepProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers with Futures
   with ScalaFutures
 {
   implicit override val patienceConfig = PatienceConfig(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/vm/PureVMDisconnectProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/vm/PureVMDisconnectProfileSpec.scala
@@ -11,8 +11,7 @@ import org.scaladebugger.api.utils.LoopingTaskRunner
 import org.scaladebugger.api.lowlevel.events.EventType.VMDisconnectEventType
 import test.JDIMockHelpers
 
-class PureVMDisconnectProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureVMDisconnectProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val mockEventManager = mock[EventManager]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/vm/PureVMStartProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/vm/PureVMStartProfileSpec.scala
@@ -11,8 +11,7 @@ import org.scaladebugger.api.pipelines.Pipeline
 import org.scaladebugger.api.utils.LoopingTaskRunner
 import test.JDIMockHelpers
 
-class PureVMStartProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureVMStartProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val mockEventManager = mock[EventManager]
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/watchpoints/PureAccessWatchpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/watchpoints/PureAccessWatchpointProfileSpec.scala
@@ -18,8 +18,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class PureAccessWatchpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureAccessWatchpointProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val stubClassManager = stub[ClassManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/watchpoints/PureModificationWatchpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/pure/watchpoints/PureModificationWatchpointProfileSpec.scala
@@ -18,8 +18,7 @@ import test.JDIMockHelpers
 
 import scala.util.{Failure, Success}
 
-class PureModificationWatchpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with JDIMockHelpers
+class PureModificationWatchpointProfileSpec extends test.ParallelMockFunSpec with JDIMockHelpers
 {
   private val TestRequestId = java.util.UUID.randomUUID().toString
   private val stubClassManager = stub[ClassManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/scala210/info/Scala210FieldInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/scala210/info/Scala210FieldInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scaladebugger.api.virtualmachines.ScalaVirtualMachine
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class Scala210FieldInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class Scala210FieldInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockNewTypeProfile = mockFunction[Type, TypeInfoProfile]
   private val mockScalaVirtualMachine = mock[ScalaVirtualMachine]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/SwappableDebugProfileManagementSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/SwappableDebugProfileManagementSpec.scala
@@ -8,8 +8,7 @@ import org.scaladebugger.api.lowlevel.events.EventType.EventType
 import org.scaladebugger.api.profiles.ProfileManager
 import org.scaladebugger.api.profiles.traits.DebugProfile
 
-class SwappableDebugProfileManagementSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableDebugProfileManagementSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/breakpoints/SwappableBreakpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/breakpoints/SwappableBreakpointProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableBreakpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableBreakpointProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/classes/SwappableClassPrepareProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/classes/SwappableClassPrepareProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableClassPrepareProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableClassPrepareProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/classes/SwappableClassUnloadProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/classes/SwappableClassUnloadProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableClassUnloadProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableClassUnloadProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/events/SwappableEventProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/events/SwappableEventProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.ProfileManager
 import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 
-class SwappableEventProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableEventProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/exceptions/SwappableExceptionProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/exceptions/SwappableExceptionProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableExceptionProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableExceptionProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/info/SwappableCreateInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/info/SwappableCreateInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import org.scaladebugger.api.profiles.traits.info.ValueInfoProfile
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class SwappableCreateInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableCreateInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/info/SwappableGrabInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/info/SwappableGrabInfoProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import sun.reflect.FieldInfo
 
-class SwappableGrabInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableGrabInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/info/SwappableMiscInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/info/SwappableMiscInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import org.scaladebugger.api.profiles.traits.info.ValueInfoProfile
 
-class SwappableMiscInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableMiscInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/methods/SwappableMethodEntryProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/methods/SwappableMethodEntryProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableMethodEntryProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableMethodEntryProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/methods/SwappableMethodExitProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/methods/SwappableMethodExitProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableMethodExitProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableMethodExitProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorContendedEnterProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorContendedEnterProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableMonitorContendedEnterProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableMonitorContendedEnterProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorContendedEnteredProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorContendedEnteredProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableMonitorContendedEnteredProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableMonitorContendedEnteredProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorWaitProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorWaitProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableMonitorWaitProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableMonitorWaitProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorWaitedProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/monitors/SwappableMonitorWaitedProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableMonitorWaitedProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableMonitorWaitedProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/steps/SwappableStepProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/steps/SwappableStepProfileSpec.scala
@@ -10,8 +10,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableStepProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableStepProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockThreadInfoProfile = mock[ThreadInfoProfile]
   private val mockDebugProfile = mock[DebugProfile]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/threads/SwappableThreadDeathProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/threads/SwappableThreadDeathProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableThreadDeathProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableThreadDeathProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/threads/SwappableThreadStartProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/threads/SwappableThreadStartProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableThreadStartProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableThreadStartProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMDeathProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMDeathProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableVMDeathProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableVMDeathProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMDisconnectProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMDisconnectProfileSpec.scala
@@ -8,8 +8,7 @@ import org.scaladebugger.api.profiles.ProfileManager
 import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 
-class SwappableVMDisconnectProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableVMDisconnectProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMStartProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/vm/SwappableVMStartProfileSpec.scala
@@ -8,8 +8,7 @@ import org.scaladebugger.api.profiles.ProfileManager
 import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 
-class SwappableVMStartProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableVMStartProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/watchpoints/SwappableAccessWatchpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/watchpoints/SwappableAccessWatchpointProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableAccessWatchpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableAccessWatchpointProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/watchpoints/SwappableModificationWatchpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/swappable/watchpoints/SwappableModificationWatchpointProfileSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.profiles.swappable.SwappableDebugProfile
 import org.scaladebugger.api.profiles.traits.DebugProfile
 import test.RequestInfoBuilder
 
-class SwappableModificationWatchpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class SwappableModificationWatchpointProfileSpec extends test.ParallelMockFunSpec
 {
   private val mockDebugProfile = mock[DebugProfile]
   private val mockProfileManager = mock[ProfileManager]

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/breakpoints/BreakpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/breakpoints/BreakpointProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class BreakpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class BreakpointProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/classes/ClassPrepareProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/classes/ClassPrepareProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class ClassPrepareProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassPrepareProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/classes/ClassUnloadProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/classes/ClassUnloadProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class ClassUnloadProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ClassUnloadProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/events/EventProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/events/EventProfileSpec.scala
@@ -13,8 +13,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class EventProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class EventProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ArrayInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ArrayInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.TestArrayInfoProfile
 
 import scala.util.{Failure, Success, Try}
 
-class ArrayInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ArrayInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("ArrayInfoProfile") {
     describe("#toPrettyString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/FrameInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/FrameInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.TestFrameInfoProfile
 
 import scala.util.{Failure, Success, Try}
 
-class FrameInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class FrameInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("FrameInfoProfile") {
     describe("#toPrettyString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/GrabInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/GrabInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import test.InfoTestClasses.TestGrabInfoProfile
 
 import scala.util.Success
 
-class GrabInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class GrabInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("GrabInfoProfile") {
     describe("#tryObject(objectReference)") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/LocationInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/LocationInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.TestLocationInfoProfile
 
 import scala.util.{Failure, Success, Try}
 
-class LocationInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class LocationInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("LocationInfoProfile") {
     describe("#toPrettyString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/MethodInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/MethodInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.TestMethodInfoProfile
 
 import scala.util.{Failure, Success, Try}
 
-class MethodInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("MethodInfoProfile") {
     describe("#toPrettyString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ObjectInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ObjectInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import test.InfoTestClasses.TestObjectInfoProfile
 
-class ObjectInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ObjectInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("ObjectInfoProfile") {
     describe("#uniqueIdHexString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/PrimitiveInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/PrimitiveInfoProfileSpec.scala
@@ -4,8 +4,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import test.InfoTestClasses.TestPrimitiveInfoProfile
 
-class PrimitiveInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PrimitiveInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("PrimitiveInfoProfile") {
     describe("#tryToLocalValue") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ReferenceTypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ReferenceTypeInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.TestReferenceTypeInfoProfile
 
 import scala.util.{Success, Try}
 
-class ReferenceTypeInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ReferenceTypeInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("ReferenceTypeInfoProfile") {
     describe("#toPrettyString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/StringInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/StringInfoProfileSpec.scala
@@ -4,8 +4,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import test.InfoTestClasses.TestStringInfoProfile
 
-class StringInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class StringInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("StringInfoProfile") {
     describe("#toPrettyString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ThreadGroupInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ThreadGroupInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.TestThreadGroupInfoProfile
 
 import scala.util.{Success, Try}
 
-class ThreadGroupInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadGroupInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("ThreadGroupInfoProfile") {
     describe("#toPrettyString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ThreadInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ThreadInfoProfileSpec.scala
@@ -7,8 +7,7 @@ import test.InfoTestClasses.TestThreadInfoProfile
 
 import scala.util.{Success, Failure, Try}
 
-class ThreadInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("ThreadInfoProfile") {
     describe("#findVariableByName") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ThreadStatusInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ThreadStatusInfoProfileSpec.scala
@@ -4,8 +4,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import test.InfoTestClasses.TestThreadStatusInfoProfile
 
-class ThreadStatusInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadStatusInfoProfileSpec extends test.ParallelMockFunSpec
 {
   private val StateMonitor = 0
   private val StateUnknown = 1

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/TypeInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/TypeInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.{TestArrayInfoProfile, TestTypeInfoProfile}
 
 import scala.util.{Failure, Success, Try}
 
-class TypeInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class TypeInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("TypeInfoProfile") {
     describe("#isBooleanType") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ValueInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/ValueInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.TestValueInfoProfile
 
 import scala.util.Failure
 
-class ValueInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ValueInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("ValueInfoProfile") {
     describe("#toPrettyString") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/VariableInfoProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/info/VariableInfoProfileSpec.scala
@@ -6,8 +6,7 @@ import test.InfoTestClasses.{TestValueInfoProfile, TestVariableInfoProfile}
 
 import scala.util.{Failure, Success, Try}
 
-class VariableInfoProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VariableInfoProfileSpec extends test.ParallelMockFunSpec
 {
   describe("VariableInfoProfile") {
     describe("#hasOffsetIndex") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/methods/MethodEntryProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/methods/MethodEntryProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class MethodEntryProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodEntryProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/methods/MethodExitProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/methods/MethodExitProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class MethodExitProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MethodExitProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorContendedEnterProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorContendedEnterProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class MonitorContendedEnterProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorContendedEnterProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorContendedEnteredProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorContendedEnteredProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class MonitorContendedEnteredProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorContendedEnteredProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorWaitProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorWaitProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class MonitorWaitProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorWaitProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorWaitedProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/monitors/MonitorWaitedProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class MonitorWaitedProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MonitorWaitedProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/threads/ThreadDeathProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/threads/ThreadDeathProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class ThreadDeathProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadDeathProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/threads/ThreadStartProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/threads/ThreadStartProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class ThreadStartProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ThreadStartProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/vm/VMDeathProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/vm/VMDeathProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class VMDeathProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VMDeathProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/vm/VMDisconnectProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/vm/VMDisconnectProfileSpec.scala
@@ -11,8 +11,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class VMDisconnectProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VMDisconnectProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/vm/VMStartProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/vm/VMStartProfileSpec.scala
@@ -11,8 +11,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class VMStartProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class VMStartProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/watchpoints/AccessWatchpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/watchpoints/AccessWatchpointProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class AccessWatchpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class AccessWatchpointProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/watchpoints/ModificationWatchpointProfileSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/profiles/traits/watchpoints/ModificationWatchpointProfileSpec.scala
@@ -12,8 +12,7 @@ import org.scaladebugger.api.pipelines.Pipeline.IdentityPipeline
 
 import scala.util.{Failure, Success, Try}
 
-class ModificationWatchpointProfileSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ModificationWatchpointProfileSpec extends test.ParallelMockFunSpec
 {
   private val TestThrowable = new Throwable
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/utils/LoopingTaskRunnerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/utils/LoopingTaskRunnerSpec.scala
@@ -9,8 +9,7 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Milliseconds, Span}
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class LoopingTaskRunnerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory with Eventually
+class LoopingTaskRunnerSpec extends test.ParallelMockFunSpec with Eventually
 {
   implicit override val patienceConfig = PatienceConfig(
     timeout = scaled(Span(300, Milliseconds)),

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/utils/MemoizationSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/utils/MemoizationSpec.scala
@@ -4,8 +4,7 @@ import acyclic.file
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ParallelTestExecution, FunSpec, Matchers}
 
-class MemoizationSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class MemoizationSpec extends test.ParallelMockFunSpec
 {
   describe("Memoization") {
     describe("#apply") {

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/utils/PendingActionManagerSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/utils/PendingActionManagerSpec.scala
@@ -7,8 +7,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.utils.ActionInfo.ActionId
 
-class PendingActionManagerSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class PendingActionManagerSpec extends test.ParallelMockFunSpec
 {
   private val TestActionId = java.util.UUID.randomUUID().toString
 

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/DummyScalaVirtualMachineSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/DummyScalaVirtualMachineSpec.scala
@@ -16,8 +16,7 @@ import org.scaladebugger.api.lowlevel.vm.{PendingVMDeathSupport, DummyVMDeathMan
 import org.scaladebugger.api.lowlevel.watchpoints.{PendingModificationWatchpointSupport, DummyModificationWatchpointManager, PendingAccessWatchpointSupport, DummyAccessWatchpointManager}
 import org.scaladebugger.api.profiles.ProfileManager
 
-class DummyScalaVirtualMachineSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class DummyScalaVirtualMachineSpec extends test.ParallelMockFunSpec
 {
   private val mockProfileManager = mock[ProfileManager]
   private val dummyScalaVirtualMachine = new DummyScalaVirtualMachine(

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/ObjectCacheSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/ObjectCacheSpec.scala
@@ -5,8 +5,7 @@ import org.scaladebugger.api.profiles.traits.info.ObjectInfoProfile
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class ObjectCacheSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ObjectCacheSpec extends test.ParallelMockFunSpec
 {
   private val TestUniqueId = 1234L
   private val internalCache =

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/ScalaVirtualMachineSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/ScalaVirtualMachineSpec.scala
@@ -8,8 +8,7 @@ import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 import org.scaladebugger.api.lowlevel.ManagerContainer
 import org.scaladebugger.api.profiles.ProfileManager
 
-class ScalaVirtualMachineSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class ScalaVirtualMachineSpec extends test.ParallelMockFunSpec
 {
   private class TestManagerContainer extends ManagerContainer(
     null, null, null, null, null, null, null, null, null, null, null, null,

--- a/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/StandardScalaVirtualMachineSpec.scala
+++ b/scala-debugger-api/src/test/scala/org/scaladebugger/api/virtualmachines/StandardScalaVirtualMachineSpec.scala
@@ -9,8 +9,7 @@ import org.scaladebugger.api.utils.LoopingTaskRunner
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
 
-class StandardScalaVirtualMachineSpec extends FunSpec with Matchers
-  with ParallelTestExecution with MockFactory
+class StandardScalaVirtualMachineSpec extends test.ParallelMockFunSpec
 {
   private val mockIsInitialized = mockFunction[Boolean]
   private val mockProcessOwnPendingRequests = mockFunction[Unit]

--- a/scala-debugger-api/src/test/scala/test/ParallelMockFunSpec.scala
+++ b/scala-debugger-api/src/test/scala/test/ParallelMockFunSpec.scala
@@ -1,0 +1,8 @@
+package test
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FunSpec, Matchers, ParallelTestExecution}
+
+
+abstract class ParallelMockFunSpec extends FunSpec with Matchers with MockFactory
+  with ParallelTestExecution with org.scalamock.matchers.Matchers


### PR DESCRIPTION
Helps a little with compile times by avoiding trait linearization on every Spec. Gets about 30 seconds back per compile.